### PR TITLE
Fix to parsing of /m switch.

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -53,7 +53,7 @@ namespace EinarEgilsson.Utilities.InjectModuleInitializer
 
             for (int i = 0; i < args.Length - 1; i++)
             {
-                var initMatch = Regex.Match(args[0], "^/m(oduleinitializer:)?(.+)", RegexOptions.IgnoreCase);
+                var initMatch = Regex.Match(args[0], "^/m(oduleinitializer)?:(.+)", RegexOptions.IgnoreCase);
                 if (initMatch.Success)
                 {
                     moduleInitializer = initMatch.Groups[2].Value;


### PR DESCRIPTION
If you use the /m shorthand switch, the old code will take the colon (:) as part of the type name causing it not to be found.
