### PR TITLE
Fix uninstall.ps1

### DIFF
--- a/nuget/tools/uninstall.ps1
+++ b/nuget/tools/uninstall.ps1
@@ -1,36 +1,7 @@
 param($installPath, $toolsPath, $package, $project)
 
-function Resolve-ProjectName {
-    param(
-        [parameter(ValueFromPipelineByPropertyName = $true)]
-        [string[]]$ProjectName
-    )
-    
-    if($ProjectName) {
-        $projects = Get-Project $ProjectName
-    }
-    else {
-        # All projects by default
-        $projects = Get-Project
-    }
-    
-    $projects
-}
-
-function Get-MSBuildProject {
-    param(
-        [parameter(ValueFromPipelineByPropertyName = $true)]
-        [string[]]$ProjectName
-    )
-    Process {
-        (Resolve-ProjectName $ProjectName) | % {
-            $path = $_.FullName
-            @([Microsoft.Build.Evaluation.ProjectCollection]::GlobalProjectCollection.GetLoadedProjects($path))[0]
-        }
-    }
-}
-
-$buildProject = Get-MSBuildProject
+Add-Type -AssemblyName 'Microsoft.Build, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
+$buildProject = [Microsoft.Build.Evaluation.ProjectCollection]::GlobalProjectCollection.GetLoadedProjects($project.FullName) | Select-Object -First 1
 $projectRoot = $buildProject.Xml;
 
 Foreach ($target in $projectRoot.Targets)


### PR DESCRIPTION
It would only remove the AfterBuild target from the project file for applications, not class libraries.
